### PR TITLE
- wait promise to save file;

### DIFF
--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -86,7 +86,7 @@ export async function main(db: IDatabase<unknown, IClient>, outputPath: string, 
   const _customTypes = parseCustomType(schema);
 
   try {
-    writeToFile(outputPath, _enums.concat(_customTypes, _interfaces), 'types');
+    await writeToFile(outputPath, _enums.concat(_customTypes, _interfaces), 'types');
     console.info('Succesfully generated files in:', outputPath);
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
direct await or return the `writeToFile` promise in order to correctly await the main postez function. I choose to await it instead of return the promise to align with other implementation