### PR TITLE
Risoluzione bug enum e aggiunta possibilità di scelta schema_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 <br>
 
 ## Usage
-Define a schema as 
+Define a types schema as 
 ```ts
-schema = {
+typesSchema = {
  'string': [ 'bpchar', 'char', 'varchar', 'text', 'citext', 'uuid' ],
  'number': ['int2', 'int4', 'int8', 'float4', 'float8', 'numeric' ],
  'boolean': ['bool', 'boolean'],
@@ -26,7 +26,23 @@ schema = {
 }
 ```
 
-then just pass it as an argument with a database connection and output path, otherwise you can use a default schema and `pg-promise` as simple as:
+then just pass it as an argument with a database connection and output path. 
+
+``` ts
+postez(db, path, typesSchema)
+  .then(() => console.log("Done."))
+  .catch((e) => console.error(e));
+```
+
+You can also specify the name of table schema you want to generate types.ts.
+
+``` ts
+postez(db, path, typesSchema, 'custom_name')
+  .then(() => console.log("Done."))
+  .catch((e) => console.error(e));
+```
+
+Otherwise you can use a default types schema (table schema name is 'public' by default if not specified) and `pg-promise` as simple as:
 
 ``` ts
 import pg from 'postez/lib/db'

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ postez(db, path, typesSchema)
 You can also specify the name of table schema you want to generate types.ts.
 
 ``` ts
-postez(db, path, typesSchema, 'custom_name')
+postez(db, path, typesSchema, 'schema_name')
   .then(() => console.log("Done."))
   .catch((e) => console.error(e));
 ```

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,4 @@
 import { IDatabase } from 'pg-promise';
 import { IClient } from 'pg-promise/typescript/pg-subset';
 import { ITypesSchema } from './types';
-export declare function postez(db: IDatabase<unknown, IClient>, path: string, schema?: ITypesSchema): Promise<void>;
+export declare function postez(db: IDatabase<unknown, IClient>, path: string, typesSchema?: ITypesSchema, schema?: string): Promise<void>;

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.postez = void 0;
 const utilities_1 = require("./utilities");
-function postez(db, path, schema) {
-    return (0, utilities_1.main)(db, path, schema);
+function postez(db, path, typesSchema, schema) {
+    return (0, utilities_1.main)(db, path, typesSchema, schema);
 }
 exports.postez = postez;

--- a/lib/parsers/datatypes.d.ts
+++ b/lib/parsers/datatypes.d.ts
@@ -1,4 +1,4 @@
 import { ITypesSchema, TParsedSchema, Types } from '../types';
-export declare function parseSchema(schema: Partial<ITypesSchema>): Record<Types, keyof ITypesSchema>;
+export declare function parseTypesSchema(schema: Partial<ITypesSchema>): Record<Types, keyof ITypesSchema>;
 export declare function enumType(enums: Map<string, string[]>, type: string): string;
 export declare function typeParser(type: Types, enums: Map<string, string[]>, schema: TParsedSchema): string;

--- a/lib/parsers/datatypes.js
+++ b/lib/parsers/datatypes.js
@@ -1,8 +1,8 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.typeParser = exports.enumType = exports.parseSchema = void 0;
+exports.typeParser = exports.enumType = exports.parseTypesSchema = void 0;
 const utilities_1 = require("../utilities");
-function parseSchema(schema) {
+function parseTypesSchema(schema) {
     return Object.keys(schema).reduce((acc, curr) => {
         acc = schema[curr].reduce((_, _curr) => {
             if (curr === 'CustomTypes' && typeof _curr === 'object') {
@@ -15,7 +15,7 @@ function parseSchema(schema) {
         return acc;
     }, {});
 }
-exports.parseSchema = parseSchema;
+exports.parseTypesSchema = parseTypesSchema;
 function enumType(enums, type) {
     if (enums.has(type))
         return (0, utilities_1.sanitizeName)(type, 'E');

--- a/lib/parsers/enums.d.ts
+++ b/lib/parsers/enums.d.ts
@@ -2,4 +2,4 @@ import { IDatabase, QueryFile } from 'pg-promise';
 import { IClient } from 'pg-promise/typescript/pg-subset';
 import { IEnumSchema } from '../types';
 export declare function parseEnumTypes(enums: IEnumSchema[]): Promise<string[]>;
-export declare function getEnums(db: IDatabase<unknown, IClient>, query: QueryFile): Promise<IEnumSchema[]>;
+export declare function getEnums(db: IDatabase<unknown, IClient>, query: QueryFile, schema: string): Promise<IEnumSchema[]>;

--- a/lib/parsers/enums.js
+++ b/lib/parsers/enums.js
@@ -23,9 +23,9 @@ function parseEnumTypes(enums) {
     });
 }
 exports.parseEnumTypes = parseEnumTypes;
-function getEnums(db, query) {
+function getEnums(db, query, schema) {
     return __awaiter(this, void 0, void 0, function* () {
-        return (yield db.manyOrNone(query));
+        return (yield db.manyOrNone(query, { schema: schema }));
     });
 }
 exports.getEnums = getEnums;

--- a/lib/parsers/interfaces.d.ts
+++ b/lib/parsers/interfaces.d.ts
@@ -1,4 +1,4 @@
 import { IDatabase, QueryFile } from 'pg-promise';
 import { IClient } from 'pg-promise/typescript/pg-subset';
 import { ITypesSchema } from '../types';
-export declare function parseInterfaces(db: IDatabase<unknown, IClient>, tableNamesCollection: string[], selectInformationSchema: QueryFile, enums: Map<string, string[]>, _schema: ITypesSchema): Promise<string[]>;
+export declare function parseInterfaces(db: IDatabase<unknown, IClient>, tableNamesCollection: string[], selectInformationSchema: QueryFile, enums: Map<string, string[]>, typesSchema: ITypesSchema, schema: string): Promise<string[]>;

--- a/lib/parsers/interfaces.js
+++ b/lib/parsers/interfaces.js
@@ -12,14 +12,15 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.parseInterfaces = void 0;
 const utilities_1 = require("../utilities");
 const datatypes_1 = require("./datatypes");
-function parseInterfaces(db, tableNamesCollection, selectInformationSchema, enums, _schema) {
+function parseInterfaces(db, tableNamesCollection, selectInformationSchema, enums, typesSchema, schema) {
     return __awaiter(this, void 0, void 0, function* () {
-        const typeSchema = (0, datatypes_1.parseSchema)(_schema);
+        const typeSchema = (0, datatypes_1.parseTypesSchema)(typesSchema);
         return yield Promise.all(tableNamesCollection.map((tableName) => __awaiter(this, void 0, void 0, function* () {
-            const schema = (yield db.manyOrNone(selectInformationSchema, {
+            const informationSchema = (yield db.manyOrNone(selectInformationSchema, {
                 table_name: tableName,
+                schema: schema,
             }));
-            const currInterface = schema.reduce((acc, curr) => {
+            const currInterface = informationSchema.reduce((acc, curr) => {
                 const type = (0, datatypes_1.typeParser)(curr.udt_name, enums, typeSchema);
                 const name = curr.column_name;
                 acc[name] = type + (curr.is_nullable === 'NO' ? '' : ' | null');

--- a/lib/parsers/tables.d.ts
+++ b/lib/parsers/tables.d.ts
@@ -1,3 +1,3 @@
 import { IDatabase, QueryFile } from 'pg-promise';
 import { IClient } from 'pg-promise/typescript/pg-subset';
-export declare function parseTableNames(db: IDatabase<unknown, IClient>, query: QueryFile): Promise<string[]>;
+export declare function parseTableNames(db: IDatabase<unknown, IClient>, query: QueryFile, schema: string): Promise<string[]>;

--- a/lib/parsers/tables.js
+++ b/lib/parsers/tables.js
@@ -10,9 +10,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.parseTableNames = void 0;
-function parseTableNames(db, query) {
+function parseTableNames(db, query, schema) {
     return __awaiter(this, void 0, void 0, function* () {
-        return yield db.map(query, undefined, (row) => row.table_name);
+        return yield db.map(query, { schema: schema }, (row) => row.table_name);
     });
 }
 exports.parseTableNames = parseTableNames;

--- a/lib/sql/select-enum-names.sql
+++ b/lib/sql/select-enum-names.sql
@@ -4,4 +4,5 @@ SELECT
 FROM pg_type t 
     JOIN pg_enum e ON t.oid = e.enumtypid  
     JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+WHERE n.nspname = { schema }
 GROUP BY enum_name;

--- a/lib/sql/select-table-information.sql
+++ b/lib/sql/select-table-information.sql
@@ -5,4 +5,4 @@ SELECT
 FROM 
    information_schema.columns
 WHERE 
-   table_name = ${table_name} and table_schema = 'public'
+   table_name = ${table_name} and table_schema = ${ schema }

--- a/lib/sql/select-table-names.sql
+++ b/lib/sql/select-table-names.sql
@@ -2,4 +2,4 @@ SELECT
 	table_name
 FROM 
 	information_schema.tables
-WHERE table_schema= 'public' AND table_type= 'BASE TABLE';
+WHERE table_schema= { schema } AND table_type= 'BASE TABLE';

--- a/lib/sql/select-view-names.sql
+++ b/lib/sql/select-view-names.sql
@@ -2,4 +2,4 @@ SELECT
 	table_name
 FROM 
 	information_schema."views"
-WHERE table_schema = 'public' and view_definition notnull 
+WHERE table_schema = { schema } and view_definition notnull 

--- a/lib/utilities.d.ts
+++ b/lib/utilities.d.ts
@@ -1,7 +1,7 @@
 import { IDatabase } from 'pg-promise';
 import { IClient } from 'pg-promise/typescript/pg-subset';
 import { IEnumSchema, ITypesSchema } from './types';
-export declare const defaultSchema: ITypesSchema;
+export declare const defaultTypesSchema: ITypesSchema;
 export declare function sanitizeName(name: string, prefix?: string, splitters?: string[]): string;
 export declare function generateEnumMap(enums: IEnumSchema[]): Map<any, any>;
 export declare function writeToFile(path: string, content: string[], name: string): Promise<void>;
@@ -10,6 +10,7 @@ export declare function writeToFile(path: string, content: string[], name: strin
  * @param {IDatabase<unknown, IClient>} db
  * @param {string} outputPath
  * @param {ITypesSchema} typesSchema
+ * @param {string} schema
  * @void will write a file to the outputPath
  */
 export declare function main(db: IDatabase<unknown, IClient>, outputPath: string, typesSchema?: ITypesSchema, schema?: string): Promise<void>;

--- a/lib/utilities.d.ts
+++ b/lib/utilities.d.ts
@@ -9,7 +9,7 @@ export declare function writeToFile(path: string, content: string[], name: strin
  * Creates a file containing all database entities and their respective interfaces
  * @param {IDatabase<unknown, IClient>} db
  * @param {string} outputPath
- * @param {ITypesSchema} schema
+ * @param {ITypesSchema} typesSchema
  * @void will write a file to the outputPath
  */
-export declare function main(db: IDatabase<unknown, IClient>, outputPath: string, schema?: ITypesSchema): Promise<void>;
+export declare function main(db: IDatabase<unknown, IClient>, outputPath: string, typesSchema?: ITypesSchema, schema?: string): Promise<void>;

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -35,13 +35,13 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.main = exports.writeToFile = exports.generateEnumMap = exports.sanitizeName = exports.defaultSchema = void 0;
+exports.main = exports.writeToFile = exports.generateEnumMap = exports.sanitizeName = exports.defaultTypesSchema = void 0;
 const fs = __importStar(require("fs"));
 const prettier = __importStar(require("prettier"));
 const os_1 = require("os");
 const db_1 = __importDefault(require("./db"));
 const parsers_1 = require("./parsers");
-exports.defaultSchema = {
+exports.defaultTypesSchema = {
     string: [
         'bpchar',
         'char',
@@ -102,9 +102,10 @@ exports.writeToFile = writeToFile;
  * @param {IDatabase<unknown, IClient>} db
  * @param {string} outputPath
  * @param {ITypesSchema} typesSchema
+ * @param {string} schema
  * @void will write a file to the outputPath
  */
-function main(db, outputPath, typesSchema = exports.defaultSchema, schema = 'public') {
+function main(db, outputPath, typesSchema = exports.defaultTypesSchema, schema = 'public') {
     return __awaiter(this, void 0, void 0, function* () {
         const tables = yield (0, parsers_1.parseTableNames)(db, db_1.default.sql('select-table-names'), schema);
         const views = yield (0, parsers_1.parseTableNames)(db, db_1.default.sql('select-view-names'), schema);

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -101,17 +101,17 @@ exports.writeToFile = writeToFile;
  * Creates a file containing all database entities and their respective interfaces
  * @param {IDatabase<unknown, IClient>} db
  * @param {string} outputPath
- * @param {ITypesSchema} schema
+ * @param {ITypesSchema} typesSchema
  * @void will write a file to the outputPath
  */
-function main(db, outputPath, schema = exports.defaultSchema) {
+function main(db, outputPath, typesSchema = exports.defaultSchema, schema = 'public') {
     return __awaiter(this, void 0, void 0, function* () {
-        const tables = yield (0, parsers_1.parseTableNames)(db, db_1.default.sql('select-table-names'));
-        const views = yield (0, parsers_1.parseTableNames)(db, db_1.default.sql('select-view-names'));
-        const enums = yield (0, parsers_1.getEnums)(db, db_1.default.sql('select-enum-names'));
+        const tables = yield (0, parsers_1.parseTableNames)(db, db_1.default.sql('select-table-names'), schema);
+        const views = yield (0, parsers_1.parseTableNames)(db, db_1.default.sql('select-view-names'), schema);
+        const enums = yield (0, parsers_1.getEnums)(db, db_1.default.sql('select-enum-names'), schema);
         const _enums = yield (0, parsers_1.parseEnumTypes)(enums);
-        const _interfaces = (yield (0, parsers_1.parseInterfaces)(db, tables, db_1.default.sql('select-table-information'), generateEnumMap(enums), schema)).concat(yield (0, parsers_1.parseInterfaces)(db, views, db_1.default.sql('select-table-information'), generateEnumMap(enums), schema));
-        const _customTypes = (0, parsers_1.parseCustomType)(schema);
+        const _interfaces = (yield (0, parsers_1.parseInterfaces)(db, tables, db_1.default.sql('select-table-information'), generateEnumMap(enums), typesSchema, schema)).concat(yield (0, parsers_1.parseInterfaces)(db, views, db_1.default.sql('select-table-information'), generateEnumMap(enums), typesSchema, schema));
+        const _customTypes = (0, parsers_1.parseCustomType)(typesSchema);
         try {
             yield writeToFile(outputPath, _enums.concat(_customTypes, _interfaces), 'types');
             console.info('Succesfully generated files in:', outputPath);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "postez",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "postez",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "license": "MIT",
       "dependencies": {
         "pg-promise": "^10.11.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postez",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Utility tool for dynamically generate interfaces from PostgreSQL",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/sql/select-enum-names.sql
+++ b/sql/select-enum-names.sql
@@ -4,4 +4,5 @@ SELECT
 FROM pg_type t 
     JOIN pg_enum e ON t.oid = e.enumtypid  
     JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+WHERE n.nspname = { schema }
 GROUP BY enum_name;

--- a/sql/select-enum-names.sql
+++ b/sql/select-enum-names.sql
@@ -4,5 +4,5 @@ SELECT
 FROM pg_type t 
     JOIN pg_enum e ON t.oid = e.enumtypid  
     JOIN pg_catalog.pg_namespace n ON n.oid = t.typnamespace
-WHERE n.nspname = { schema }
+WHERE n.nspname = ${ schema }
 GROUP BY enum_name;

--- a/sql/select-table-information.sql
+++ b/sql/select-table-information.sql
@@ -5,4 +5,4 @@ SELECT
 FROM 
    information_schema.columns
 WHERE 
-   table_name = ${table_name} and table_schema = 'public'
+   table_name = ${table_name} and table_schema = ${ schema }

--- a/sql/select-table-names.sql
+++ b/sql/select-table-names.sql
@@ -2,4 +2,4 @@ SELECT
 	table_name
 FROM 
 	information_schema.tables
-WHERE table_schema= 'public' AND table_type= 'BASE TABLE';
+WHERE table_schema= { schema } AND table_type= 'BASE TABLE';

--- a/sql/select-table-names.sql
+++ b/sql/select-table-names.sql
@@ -2,4 +2,4 @@ SELECT
 	table_name
 FROM 
 	information_schema.tables
-WHERE table_schema= { schema } AND table_type= 'BASE TABLE';
+WHERE table_schema= ${ schema } AND table_type= 'BASE TABLE';

--- a/sql/select-view-names.sql
+++ b/sql/select-view-names.sql
@@ -2,4 +2,4 @@ SELECT
 	table_name
 FROM 
 	information_schema."views"
-WHERE table_schema = 'public' and view_definition notnull 
+WHERE table_schema = { schema } and view_definition notnull 

--- a/sql/select-view-names.sql
+++ b/sql/select-view-names.sql
@@ -2,4 +2,4 @@ SELECT
 	table_name
 FROM 
 	information_schema."views"
-WHERE table_schema = { schema } and view_definition notnull 
+WHERE table_schema = ${ schema } and view_definition notnull 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,6 @@ import { IClient } from 'pg-promise/typescript/pg-subset';
 import { ITypesSchema } from './types';
 import { main } from './utilities';
 
-export function postez(db: IDatabase<unknown, IClient>, path: string, schema?: ITypesSchema) {
-  return main(db, path, schema);
+export function postez(db: IDatabase<unknown, IClient>, path: string, typesSchema?: ITypesSchema, schema?: string) {
+  return main(db, path, typesSchema, schema);
 }

--- a/src/parsers/datatypes.ts
+++ b/src/parsers/datatypes.ts
@@ -1,7 +1,7 @@
 import { ICustomType, ITypesSchema, TParsedSchema, Types } from '../types';
 import { sanitizeName } from '../utilities';
 
-export function parseSchema(schema: Partial<ITypesSchema>): Record<Types, keyof ITypesSchema> {
+export function parseTypesSchema(schema: Partial<ITypesSchema>): Record<Types, keyof ITypesSchema> {
   return Object.keys(schema).reduce((acc, curr) => {
     acc = schema[curr].reduce((_: never, _curr: string | ICustomType) => {
       if (curr === 'CustomTypes' && typeof _curr === 'object') {

--- a/src/parsers/enums.ts
+++ b/src/parsers/enums.ts
@@ -14,6 +14,6 @@ export async function parseEnumTypes(enums: IEnumSchema[]) {
   });
 }
 
-export async function getEnums(db: IDatabase<unknown, IClient>, query: QueryFile) {
-  return (await db.manyOrNone(query)) as IEnumSchema[];
+export async function getEnums(db: IDatabase<unknown, IClient>, query: QueryFile, schema: string) {
+  return (await db.manyOrNone(query, { schema: schema })) as IEnumSchema[];
 }

--- a/src/parsers/interfaces.ts
+++ b/src/parsers/interfaces.ts
@@ -2,24 +2,26 @@ import { IDatabase, QueryFile } from 'pg-promise';
 import { IClient } from 'pg-promise/typescript/pg-subset';
 import { IInterfaces, ITypesSchema } from '../types';
 import { sanitizeName } from '../utilities';
-import { parseSchema, typeParser } from './datatypes';
+import { parseTypesSchema, typeParser } from './datatypes';
 
 export async function parseInterfaces(
   db: IDatabase<unknown, IClient>,
   tableNamesCollection: string[],
   selectInformationSchema: QueryFile,
   enums: Map<string, string[]>,
-  _schema: ITypesSchema,
+  typesSchema: ITypesSchema,
+  schema: string,
 ) {
-  const typeSchema = parseSchema(_schema);
+  const typeSchema = parseTypesSchema(typesSchema);
 
   return await Promise.all(
     tableNamesCollection.map(async (tableName) => {
-      const schema = (await db.manyOrNone(selectInformationSchema, {
+      const informationSchema = (await db.manyOrNone(selectInformationSchema, {
         table_name: tableName,
+        schema: schema,
       })) as IInterfaces[];
 
-      const currInterface = schema.reduce((acc, curr) => {
+      const currInterface = informationSchema.reduce((acc, curr) => {
         const type = typeParser(curr.udt_name, enums, typeSchema);
 
         const name = curr.column_name;

--- a/src/parsers/tables.ts
+++ b/src/parsers/tables.ts
@@ -1,6 +1,10 @@
 import { IDatabase, QueryFile } from 'pg-promise';
 import { IClient } from 'pg-promise/typescript/pg-subset';
 
-export async function parseTableNames(db: IDatabase<unknown, IClient>, query: QueryFile): Promise<string[]> {
-  return await db.map<string>(query, undefined, (row: { table_name: string }) => row.table_name);
+export async function parseTableNames(
+  db: IDatabase<unknown, IClient>,
+  query: QueryFile,
+  schema: string,
+): Promise<string[]> {
+  return await db.map<string>(query, { schema: schema }, (row: { table_name: string }) => row.table_name);
 }

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -9,7 +9,7 @@ import pg from './db';
 import { IEnumSchema, ITypesSchema } from './types';
 import { parseTableNames, getEnums, parseEnumTypes, parseInterfaces, parseCustomType } from './parsers';
 
-export const defaultSchema: ITypesSchema = {
+export const defaultTypesSchema: ITypesSchema = {
   string: [
     'bpchar',
     'char',
@@ -72,12 +72,13 @@ export async function writeToFile(path: string, content: string[], name: string)
  * @param {IDatabase<unknown, IClient>} db
  * @param {string} outputPath
  * @param {ITypesSchema} typesSchema
+ * @param {string} schema
  * @void will write a file to the outputPath
  */
 export async function main(
   db: IDatabase<unknown, IClient>,
   outputPath: string,
-  typesSchema: ITypesSchema = defaultSchema,
+  typesSchema: ITypesSchema = defaultTypesSchema,
   schema: string = 'public',
 ) {
   const tables = await parseTableNames(db, pg.sql('select-table-names'), schema);


### PR DESCRIPTION
Risolto il bug sugli enum che venivano generati senza tenere conto degli schema_name nella query.
Aggiunta la possibilità di inserire lo schema_name specificandolo nella chiamata come parametro aggiuntivo.
Aggiornato il readme.MD.